### PR TITLE
Add test for list in para in exercise in section

### DIFF
--- a/test/de/section.js
+++ b/test/de/section.js
@@ -1,31 +1,42 @@
 /** @jsx h */
 
 export const input = cnxml`
-<section id="s1">
-    <title>Section</title>
-    <para>This is a section</para>
-    <section id="s2">
-        <title>Another section</title>
-        <para>This is a sub-section</para>
-    </section>
-</section>
 <section id="s3">
     <title>One more section</title>
-    <para>Only sections can follow sections</para>
+    <exercise>
+        <problem>
+            <para>Only sections can follow sections
+                <list>
+                    <item>item</item>
+                </list>
+            </para>
+        </problem>
+    </exercise>
 </section>
 `
 
 export const output = <document>
-    <section id="s1">
-        <title>Section</title>
-        <p>This is a section</p>
-        <section id="s2">
-            <title>Another section</title>
-            <p>This is a sub-section</p>
-        </section>
-    </section>
     <section id="s3">
         <title>One more section</title>
-        <p>Only sections can follow sections</p>
+        <exercise>
+            <exproblem>
+                <p>Only sections can follow sections </p>
+                <itemlist>
+                    <li><p>item</p></li>
+                </itemlist>
+                <p><text/></p>
+            </exproblem>
+        </exercise>
     </section>
 </document>
+
+export const errors = [
+    [
+      "unexpected-element",
+      {
+        "id": null,
+        "localName": "list",
+        "namespace": "http://cnx.rice.edu/cnxml",
+      }
+    ]
+]


### PR DESCRIPTION
https://app.zenhub.com/workspaces/adaptarr-5d2f43c60f37561a03177ab7/issues/openstax-poland/adaptarr-front/639

@aiwenar This is the case from the draft linked in the issue that is failing to load. It happens only if an exercise is in the section.
Also, if you change:
```
    </list>
  </para>
</problem>
```
to:
```
    </list></para>
</problem>
```
then it will work.
It is failing after processing line `135` from `whitespace.ts`
```js
Transforms.delete(editor, { at: Editor.range(editor, end, at) })
```
Very weird thing happens after this action. You can check it by adding
```
console.log('editor before', JSON.stringify(editor.children, null, 2))
console.log('range to delete', Editor.range(editor, end, at))
Transforms.delete(editor, { at: Editor.range(editor, end, at) })
console.log('editor after', JSON.stringify(editor.children, null, 2))
```
From what I can see the range to delete is correct, but after the deletion, list is unwrapped from the exercise and merged into the `title` from the `section`.
I don't really have more ideas on what is broken here. It seems like it should work (it is working if exercise is not wrapped with section). Please take a look at it